### PR TITLE
Add server route for fetching all blog posts

### DIFF
--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,15 +1,16 @@
 import { error } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 import type { Post } from '$lib/types';
-import { getMarkdownPosts } from '$lib/utils';
 
 export const prerender = true;
 
-export const load: LayoutServerLoad = async ({ url }) => {
+export const load: LayoutServerLoad = async ({ url, fetch }) => {
 	const { pathname } = url;
 
 	try {
-		const posts: Post[] = await getMarkdownPosts();
+		const res = await fetch('/api/posts');
+		const posts: Post[] = await res.json();
+
 		return { posts, pathname };
 	} catch (e) {
 		console.error(e);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,7 +13,7 @@
 
 <svelte:window bind:innerWidth />
 
-<body class:no-scrollbar={inTransition} class="dark:bg-gray-800 dark:text-gray-200 font-sans">
+<body class:no-scrollbar={inTransition} class="bg-gray-800 text-gray-200 font-sans">
 	{#key data.pathname}
 		<div
 			in:fly={{ x: 10, delay: 400, duration: 300, easing: cubicInOut }}

--- a/src/routes/api/posts/+server.ts
+++ b/src/routes/api/posts/+server.ts
@@ -1,0 +1,7 @@
+import { getMarkdownPosts } from '$lib/utils';
+import { json } from '@sveltejs/kit';
+
+export const GET = async () => {
+	const posts = await getMarkdownPosts();
+	return json(posts);
+};


### PR DESCRIPTION
Moved logic for retrieving blog posts to a GET server route at `/api/posts`