### PR TITLE
Add dynamic 'scroll to top' and 'see all'

### DIFF
--- a/src/lib/components/BackToTop.svelte
+++ b/src/lib/components/BackToTop.svelte
@@ -11,12 +11,11 @@
 
 <div on:click={scrollToTop} on:keydown={scrollToTop} role="button" tabindex="0">
 	<h1>back to top</h1>
-	<Icon icon="mdi:arrow-up-bold-outline" width="24" height="24" />
+	<Icon icon="akar-icons:arrow-up" width="24" height="24" />
 </div>
 
 <style>
 	div {
-		@apply font-serif;
 		position: relative;
 		left: 0;
 		display: flex;

--- a/src/lib/components/Projects.svelte
+++ b/src/lib/components/Projects.svelte
@@ -1,5 +1,5 @@
 <script>
-	import Project from '$lib/components/Project.svelte';
+	import { Project } from '$lib/components';
 	import projects from '$lib/projects';
 </script>
 

--- a/src/lib/components/ScrollableWrapper.svelte
+++ b/src/lib/components/ScrollableWrapper.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { isPageScrollable } from '$lib/utils';
+	import { onMount } from 'svelte';
+
+	let scrollable: boolean;
+
+	onMount(() => {
+		window.addEventListener('resize', async () => {
+			scrollable = await isPageScrollable(100);
+		});
+	});
+
+	
+</script>
+
+{#if scrollable}
+    <slot />
+{/if}

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -1,2 +1,8 @@
 import img from './img.svelte';
-export { img };
+import BackToTop from './BackToTop.svelte';
+import Blog from './Blog.svelte';
+import HoverLink from './HoverLink.svelte';
+import Project from './Project.svelte';
+import Projects from './Projects.svelte';
+import ScrollableWrapper from './ScrollableWrapper.svelte';
+export { img, BackToTop, Blog, HoverLink, Project, Projects, ScrollableWrapper };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,11 @@
 import type { Post } from './types';
 
+export async function isPageScrollable(offset: number): Promise<boolean> {
+	const pageHeight = document.body.scrollHeight;
+	const windowHeight = window.innerHeight;
+	return pageHeight > windowHeight + offset;
+}
+
 export const pickRandom = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)];
 
 export async function getMarkdownPosts(): Promise<Post[]> {

--- a/src/mdsvex.svelte
+++ b/src/mdsvex.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" context="module">
-	import { img } from '$lib/components/index';
+	import { img } from '$lib/components';
 	export { img };
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import HoverLink from '$lib/components/HoverLink.svelte';
+	import { HoverLink } from '$lib/components';
 	import { fly } from 'svelte/transition';
 	import { cubicInOut, sineOut } from 'svelte/easing';
 	import { socialLinks } from '$lib/socialLinks';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import HeroText from './HeroText.svelte';
-	import Projects from '$lib/components/Projects.svelte';
-	import Blog from '$lib/components/Blog.svelte';
+	import { Projects, Blog } from '$lib/components';
 	import { title } from '$lib/config';
+	import Icon from '@iconify/svelte';
 
 	export let data;
 </script>
@@ -16,9 +16,25 @@
 <div class="my-16">
 	<HeroText />
 </div>
-<h1 class="font-bold text-3xl my-4">projects.</h1>
+
+<div class="mt-8 mb-4 flex flex-row justify-between items-center">
+	<h1 class="font-bold text-3xl">projects.</h1>
+	<a href="/portfolio/">
+		<p class="text-2xl">see all
+			<Icon icon="akar-icons:arrow-right" class="inline-block w-6 h-6" />
+		</p>
+	</a>
+</div>
 <Projects />
-<h1 class="font-bold text-3xl mt-8 mb-4">blog.</h1>
+<div class="mt-8 mb-4 flex flex-row justify-between items-center">
+	<h1 class="font-bold text-3xl">blog.</h1>
+	<a href="/blog/">
+		<p class="text-2xl">see all
+			<Icon icon="akar-icons:arrow-right" class="inline-block w-6 h-6" />
+		</p>
+	</a>
+</div>
+
 <Blog limit={3} posts={data.posts} />
 
 <style>

--- a/src/routes/blog/+layout.svelte
+++ b/src/routes/blog/+layout.svelte
@@ -1,6 +1,9 @@
-<script>
-	import BackToTop from '$lib/components/BackToTop.svelte';
+<script lang="ts">
+	import { BackToTop, ScrollableWrapper } from '$lib/components';
 </script>
 
 <slot />
-<BackToTop />
+
+<ScrollableWrapper>
+	<BackToTop />
+</ScrollableWrapper>

--- a/src/routes/portfolio/+layout.svelte
+++ b/src/routes/portfolio/+layout.svelte
@@ -1,6 +1,9 @@
 <script>
-	import BackToTop from '$lib/components/BackToTop.svelte';
+	import { BackToTop, ScrollableWrapper } from '$lib/components';
 </script>
 
 <slot />
-<BackToTop />
+
+<ScrollableWrapper>
+	<BackToTop />
+</ScrollableWrapper>

--- a/src/routes/portfolio/+page.svelte
+++ b/src/routes/portfolio/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import Projects from '$lib/components/Projects.svelte';
+	import { Projects } from '$lib/components';
 </script>
 
 <Projects />


### PR DESCRIPTION
Added:
- Dynamic "scroll to top" button that only appears when the page height is greater than the window height (with offset)
- "See all" button on the homepage to see `/blog` and `/portfolio`
- Added exports to `$lib/components/index.ts` for easier importing in other parts of the codebase